### PR TITLE
cloneref extra checks

### DIFF
--- a/src/tests/standards/checks/Instances/cloneref.luau
+++ b/src/tests/standards/checks/Instances/cloneref.luau
@@ -11,16 +11,68 @@ return function()
 
 	local originalPart = Instance.new("Part")
 	local originalService = game:GetService("CoreGui")
-
-	if cloneref(originalPart) == originalPart then
+	
+	if cloneref(originalService) == originalService then
 		return {
 			status = 500,
-			message = `Cloned part cannot be equal to original reference`,
+			message = "Cloned service cannot be equal to original reference",
 		}
-	elseif cloneref(originalService) == originalService then
+	end
+	
+	-- An "error" is only possible if setrawmetatable exists and was previously modified
+	if setrawmetatable then
+		setrawmetatable(originalPart, {
+			__type = "Instance",
+			__index = function()
+				return {}
+			end
+		})
+	end
+
+	local originalPartNewRef = cloneref(originalPart)
+	local collectGarbageDetecor = setmetatable({{}, originalPart}, {__mode = "v"})
+	
+	pcall(function()
+		originalPartNewRef.Name = math.random()
+	end)
+	
+	if originalPart == originalPartNewRef then
 		return {
 			status = 500,
-			message = `Cloned service cannot be equal to original reference`,
+			message = "Cloned part cannot be equal to original reference",
+		}
+	elseif originalPart.Name ~= originalPartNewRef.Name then
+		return {
+			status = 500,
+			message = "The new xref does not contain the same metadata as the original",
+		}
+	end
+
+	originalPart = nil
+	
+	local timeout = false
+	local cancelThread = task.delay(5, function()
+		timeout = true
+		collectGarbageDetecor[1] = nil
+	end)
+	
+	while collectGarbageDetecor[1] do
+		task.wait()
+	end
+	
+	if not timeout then
+		task.cancel(cancelThread)
+	else
+		return {
+			status = 500,
+			message = "The garbage collector is not functioning properly",
+		}
+	end
+
+	if collectGarbageDetecor[2] then
+		return {
+			status = 500,
+			message = "Cloned part still holds the original xref",
 		}
 	end
 

--- a/src/tests/standards/checks/Instances/cloneref.luau
+++ b/src/tests/standards/checks/Instances/cloneref.luau
@@ -65,7 +65,7 @@ return function()
 	else
 		return {
 			status = 500,
-			message = "The garbage collector is not functioning properly",
+			message = "The garbage collector is not working properly. It should have cleaned up in 2 seconds, but it took more",
 		}
 	end
 


### PR DESCRIPTION
It has a timeout because exploits like Xeno usually take around 15 seconds and perform poorly; normally, it should take 2 seconds