### PR TITLE
firesignal extra checks

### DIFF
--- a/src/tests/standards/checks/Signals/firesignal.luau
+++ b/src/tests/standards/checks/Signals/firesignal.luau
@@ -8,48 +8,176 @@ return function()
 			message = "Global not found",
 		}
 	end
+	
+	local NoChildsService = game:GetService("SocialService")
+	local BindableEv = Instance.new("BindableEvent")
+	BindableEv.Name = "MYRIAD_FIRESIGNAL"
 
-	local Event = Instance.new("BindableEvent")
-	local fired = false
-	local args = nil
-	local conn = Event.Event:Connect(function(...)
-		fired = true
-		args = {...}
+	local detectedOnceStacks = false
+
+	local randomObject = Instance.new("TrussPart", BindableEv)
+	local randomString = ""
+
+	for _ = 1, 8 do
+		randomString ..= string.char(math.random(1, 255))
+	end
+
+	randomObject.Name = randomString
+
+	local onceRecibedArgs, waitRecibedArgs
+	
+	task.spawn(function()
+		waitRecibedArgs = table.pack(BindableEv.Event:Wait())
 	end)
+
+	BindableEv.Event:Once(function(...)
+		for StackLevel = 2, 20 do
+			if debug.info(StackLevel, "f") then
+				detectedOnceStacks = true
+			end
+		end
+
+		local entersCount = debug.traceback():split("\n")
+		if not entersCount or #entersCount > 2 then
+			detectedOnceStacks = true
+		end
+
+		onceRecibedArgs = table.pack(...)
+	end)
+
+	BindableEv.Parent = NoChildsService
+	
+	task.wait(0.1)
 
 	local s, e = pcall(function()
-		firesignal(Event.Event, "Hello", 123)
+		firesignal(BindableEv.Event, randomString, randomObject, nil)
 	end)
+	
+	local destroyEvent = function()
+		if BindableEv.Parent then
+			BindableEv:Destroy()
+		end
+	end
+	
+	task.delay(1, destroyEvent)
 
 	task.wait()
 
 	if not s then
-		conn:Disconnect()
 		return {
 			status = 0,
 			message = `Ambiguous error: {e}`,
 		}
-	end
-
-	conn:Disconnect()
-
-	if not fired then
+	elseif type(onceRecibedArgs) ~= "table" then
 		return {
 			status = 500,
-			message = "Signal handler did not run when fired",
+			message = "Signal handler did not run an :Once",
+		}
+	elseif type(waitRecibedArgs) ~= "table" then
+		return {
+			status = 500,
+			message = "Signal handler did not run an :Wait",
 		}
 	end
 
-	if type(args) ~= "table" or args[1] ~= "Hello" or args[2] ~= 123 then
+	if onceRecibedArgs[1] ~= randomString or
+		onceRecibedArgs[2] ~= randomObject or
+		onceRecibedArgs[3] ~= nil or
+		onceRecibedArgs.n ~= 3 then
+
 		return {
 			status = 500,
-			message = "Arguments passed to firesignal were not received by the handler",
+			message = "Arguments passed to firesignal with Once were not received by the handler",
 		}
+
+	elseif waitRecibedArgs[1] ~= randomString or
+		waitRecibedArgs[2] ~= randomObject or
+		waitRecibedArgs[3] ~= nil or
+		waitRecibedArgs.n ~= 3 then
+
+		return {
+			status = 500,
+			message = "Arguments passed to firesignal with Wait were not received by the handler",
+		}
+	elseif detectedOnceStacks then -- firesignal should obtain the function and execute it in a NEW Thread
+		return {
+			status = 500,
+			message = "The function is being executed instead of creating a separate thread",
+		}
+	end
+
+	local actorResponseTimeStart = tick()
+	local actorResponse
+
+	while not actorResponse and tick() - actorResponseTimeStart < 0.5 do
+		actorResponse = randomObject:FindFirstChildWhichIsA("StringValue")
+		if actorResponse then
+			actorResponse = actorResponse.Value
+			break
+		end
+
+		task.wait()
+	end
+	
+	task.spawn(destroyEvent)
+
+	--[[ ERROR_O3 EXPLANATION:
+		
+		> Unlike run_on_actor, this is not directed towards an exploit function, so 
+		it is mandatory that all tables are cloned and that the instances 
+		provide their usable xrefs in the different state.
+		
+		> Only in this case should you use SendMessage and BindToMessage (Or create 
+		something that does the same thing).
+	]]
+
+	if not actorResponse then
+		return {
+			status = 500,
+			message = "Our actor took too long to respond",
+		}
+	end
+
+	local conditionsInfo = {
+		{Prefix = "O", Function = ":Once"},
+		{Prefix = "W", Function = ":Wait"}
+	}
+
+	for _, Condition in conditionsInfo do
+		local Prefix = Condition.Prefix
+		local Function = Condition.Function
+
+		if actorResponse == `ERROR_{Prefix}1` then
+			return {
+				status = 500,
+				message = `Signal handler did not run a {Function} in an actor`,
+			}
+		elseif actorResponse == `ERROR_{Prefix}2` then
+			return {
+				status = 500,
+				message = `Signal handler does not provide correct args in an {Function} of an Actor`,
+			}
+		elseif actorResponse == `ERROR_{Prefix}3` then
+			return {
+				status = 500,
+				message = `Signal handler does convert the {Function} xrefs in the arguments of and Actor`,
+			}
+		elseif actorResponse == `ERROR_{Prefix}4` then
+			return {
+				status = 500,
+				message = `Signal handler does not provide all args in an {Function} of an Actor`,
+			}
+		elseif actorResponse == "ERROR_O5" then -- Exclusive to :Once because its a function
+			return {
+				status = 500,
+				message = `The function of an Actor is being executed instead of creating a separate thread`,
+			}
+		end
 	end
 
 	--// Alias test
 	local envIndex, failedIndex = require("@dependencies/aliasTest.luau")({})
-    
+
 	if not envIndex then
 		return {
 			status = 501,

--- a/src/tests/standards/checks/Signals/firesignal.luau
+++ b/src/tests/standards/checks/Signals/firesignal.luau
@@ -13,6 +13,23 @@ return function()
 	local BindableEv = Instance.new("BindableEvent")
 	BindableEv.Name = "MYRIAD_FIRESIGNAL"
 
+	--[[
+	
+		> As you can see, we believe that firesignal should also influence Actors. THE REASON? 
+		Traditional RBXScriptSignals affect the entire game, so executing them only in the 
+		normal State could cause the game to not perform the action or, worse still, BE DETECTED 
+		by a comparison within the Actors.
+		
+		ERROR_O3 EXPLANATION:
+			> Unlike run_on_actor, this is not directed towards an exploit function, so 
+			it is mandatory that all tables are cloned and that the instances 
+			provide their usable xrefs in the different state.
+		
+			> Only in this case should you use SendMessage and BindToMessage (Or create 
+			something that does the same thing).
+			
+	]]
+
 	local detectedOnceStacks = false
 
 	local randomObject = Instance.new("TrussPart", BindableEv)
@@ -24,10 +41,10 @@ return function()
 
 	randomObject.Name = randomString
 
-	local onceRecibedArgs, waitRecibedArgs
+	local onceReceivedArgs, waitReceivedArgs
 	
 	task.spawn(function()
-		waitRecibedArgs = table.pack(BindableEv.Event:Wait())
+		waitReceivedArgs = table.pack(BindableEv.Event:Wait())
 	end)
 
 	BindableEv.Event:Once(function(...)
@@ -42,7 +59,7 @@ return function()
 			detectedOnceStacks = true
 		end
 
-		onceRecibedArgs = table.pack(...)
+		onceReceivedArgs = table.pack(...)
 	end)
 
 	BindableEv.Parent = NoChildsService
@@ -68,32 +85,32 @@ return function()
 			status = 0,
 			message = `Ambiguous error: {e}`,
 		}
-	elseif type(onceRecibedArgs) ~= "table" then
+	elseif type(onceReceivedArgs) ~= "table" then
 		return {
 			status = 500,
 			message = "Signal handler did not run an :Once",
 		}
-	elseif type(waitRecibedArgs) ~= "table" then
+	elseif type(waitReceivedArgs) ~= "table" then
 		return {
 			status = 500,
 			message = "Signal handler did not run an :Wait",
 		}
 	end
 
-	if onceRecibedArgs[1] ~= randomString or
-		onceRecibedArgs[2] ~= randomObject or
-		onceRecibedArgs[3] ~= nil or
-		onceRecibedArgs.n ~= 3 then
+	if onceReceivedArgs[1] ~= randomString or
+		onceReceivedArgs[2] ~= randomObject or
+		onceReceivedArgs[3] ~= nil or
+		onceReceivedArgs.n ~= 3 then
 
 		return {
 			status = 500,
 			message = "Arguments passed to firesignal with Once were not received by the handler",
 		}
 
-	elseif waitRecibedArgs[1] ~= randomString or
-		waitRecibedArgs[2] ~= randomObject or
-		waitRecibedArgs[3] ~= nil or
-		waitRecibedArgs.n ~= 3 then
+	elseif waitReceivedArgs[1] ~= randomString or
+		waitReceivedArgs[2] ~= randomObject or
+		waitReceivedArgs[3] ~= nil or
+		waitReceivedArgs.n ~= 3 then
 
 		return {
 			status = 500,
@@ -120,16 +137,6 @@ return function()
 	end
 	
 	task.spawn(destroyEvent)
-
-	--[[ ERROR_O3 EXPLANATION:
-		
-		> Unlike run_on_actor, this is not directed towards an exploit function, so 
-		it is mandatory that all tables are cloned and that the instances 
-		provide their usable xrefs in the different state.
-		
-		> Only in this case should you use SendMessage and BindToMessage (Or create 
-		something that does the same thing).
-	]]
 
 	if not actorResponse then
 		return {
@@ -160,7 +167,7 @@ return function()
 		elseif actorResponse == `ERROR_{Prefix}3` then
 			return {
 				status = 500,
-				message = `Signal handler does convert the {Function} xrefs in the arguments of and Actor`,
+				message = `The Signal handler does not create new xrefs for the {Function} arguments of an Actor`,
 			}
 		elseif actorResponse == `ERROR_{Prefix}4` then
 			return {


### PR DESCRIPTION
## Changes:
[+] Checks added for :Wait (Potassium fails).

[+] Now checks that the Signal is also sent to the Actors (Reason? In Roblox, when an RBXScriptSignal from the game is launched, all States react to it).

### For exploits that do not send signals to Actors, I recommend that you ONLY use SendMessage and BindToMessage (with a random and long topic, please) for firesignal, as it automatically converts the arguments to the State of the actors.