### PR TITLE
run_on_actor table check update

### DIFF
--- a/src/tests/standards/checks/Actors/run_on_actor.luau
+++ b/src/tests/standards/checks/Actors/run_on_actor.luau
@@ -29,8 +29,15 @@ return function()
 		["TABLE_STR"] = tostring(detectXref)
 	}
 	
-	local success, errorMessage = pcall(run_on_actor, actor, "A = ...", {})
-	if not success then
+	local success, errorMessage = pcall(run_on_actor, actor, [[local Table = ...
+    workspace:SetAttribute("MYRIAD_ROA_TABLETEST", type(Table) == "table")]], {})
+	
+	task.wait(0.1)
+	
+	local receivedTable = workspace:GetAttribute("MYRIAD_ROA_TABLETEST")
+	workspace:SetAttribute("MYRIAD_ROA_TABLETEST", nil)
+	
+	if not success or not receivedTable then
 		return {
 			status = 500,
 			message = "Does not support tables as argument"


### PR DESCRIPTION
When testing Ronix, I realized that when you try to send a table, it doesn't give an error, but the actor doesn't receive it as an argument. It seems like it tries to delete it or hides the error