### PR TITLE
cloneref fix

### DIFF
--- a/src/tests/standards/checks/Instances/cloneref.luau
+++ b/src/tests/standards/checks/Instances/cloneref.luau
@@ -21,10 +21,11 @@ return function()
 	
 	-- An "error" is only possible if setrawmetatable exists and was previously modified
 	if setrawmetatable then
+		local sameTable = {}
 		setrawmetatable(originalPart, {
 			__type = "Instance",
 			__index = function()
-				return {}
+				return sameTable
 			end
 		})
 	end


### PR DESCRIPTION
I am very sorry for this error. Every time __index was used, it would return new tables (thanks, Tiahh, for letting us know)